### PR TITLE
Add language to CodeQL job status Slack messages

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: 8398a7/action-slack@v3
       with:
         status: ${{ job.status }}
-        author_name: CodeQL analysis
+        author_name: CodeQL ${{ matrix.language }} analysis
         fields: repo,eventName,ref,workflow
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SALISHSEACAST_WEBHOOK_URL }}


### PR DESCRIPTION
This should resolve confusion about why there are 2 CodeQL status messages every time the workflow runs; one is the Python analysis, the other is the Javascript.