### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -3,6 +3,9 @@ name: pytest-with-coverage
 on:
   push:
     branches: [ '*' ]
+  # Enable workflow to be triggered from GitHub CLI, browser, or via API
+  # primarily for testing conda env solution for new Python versions
+  workflow_dispatch:
 
 jobs:
   pytest-with-coverage:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/pytest-with-coverage.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -71,7 +71,7 @@ toml==0.10.2
 tomli==2.0.1
 translationstring==1.4
 typing_extensions==4.4.0
-urllib3==1.26.17
+urllib3==1.26.18
 venusian==3.0.0
 waitress==2.1.2
 WebOb==1.8.7


### PR DESCRIPTION
- [x] Add Python 3.12 to GHA pytest-with-coverage workflow so that we can use the workflow to test whether all the packages NEMO-Cmd depends on have been updated to support Python 3.12.
- [x] Add `workflow_dispatch` trigger to GHA pytest-with-coverage workflow to enable workflow to be triggered from
GitHub CLI, browser or via API
- [ ] Drop Python 3.10 & 3.11 from GHA pytest-with-coverage workflow
- [ ] Change `setup.cfg python_requires` to >=3.12
- [ ] Change conda environment descriptions to use Python 3.12
  - [ ] `environment-dev.yaml`
  - [ ] `environment-prod.yaml`
  - [ ] `environment-rtd.yaml`
- [ ] Change sphinx-linkcheck workflow to Python 3.12
- [ ] Change index doc & README to Python 3.12 for package development