### PR TITLE
Add explicit Sphinx configuration for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@ build:
   tools:
     python: "mambaforge-23.11"
 
+sphinx:
+    builder: html
+    configuration: docs/conf.py
+    fail_on_warning: false
+
 conda:
   environment: envs/environment-rtd.yaml
 


### PR DESCRIPTION
Updated `.readthedocs.yaml` to define Sphinx builder settings, including the builder type, configuration file path, and `fail_on_warning` option. This is necessary due to readthedocs deprecating projects without explicit builder configuration that comes into effect on 20-Jan-2025.